### PR TITLE
Add QUEUE EVENTS that are used by the script

### DIFF
--- a/FakeDetector.py
+++ b/FakeDetector.py
@@ -23,6 +23,7 @@
 
 ##############################################################################
 ### NZBGET QUEUE/POST-PROCESSING SCRIPT                                    ###
+### QUEUE EVENTS: NZB_ADDED, NZB_DOWNLOADED, FILE_DOWNLOADED
 
 # Detect nzbs with fake media files.
 #


### PR DESCRIPTION
This prevents that nzbget calls the script for events that it doesn't support. 

Calling the script of events can especially on low powered devices slow down things and put unnecessary strains on the device.