### PR TITLE
Exclude paths with "reverse" or "spiegelen" in the name (NL releases)…

### DIFF
--- a/FakeDetector.py
+++ b/FakeDetector.py
@@ -141,7 +141,15 @@ def contains_banned_media(list):
 def contains_executable(list):
 	exExtensions = [ '.exe', '.bat', '.sh' ]
 	allowNames = [ 'rename', 'Rename' ]
+	excludePath = [ r'reverse', r'spiegelen' ]
 	for item in list:
+		ep = False
+		for ap in excludePath:
+			if re.search(ap, item, re.I):
+				ep = True
+				break
+		if ep:
+			continue
 		name, ext = os.path.splitext(item)
 		if os.path.split(name)[1] != "":
 			name = os.path.split(name)[1]


### PR DESCRIPTION
… from executable search

Some NL releases have a folder like:

`LEES DIT OOK, BESTANDSNAAM MAKKELIJK TE SPIEGELEN QOQREVERSE`

which contains a setup.exe to reverse the file name back. These will currently be marked bad as fake but are not fake. 

This PR will exclude all paths that have 'reverse' or 'spiegelen' in the name to prevent this false fake detection.